### PR TITLE
Make the ob-elasticsearch mode accept and send utf-8

### DIFF
--- a/test/all.org
+++ b/test/all.org
@@ -36,7 +36,7 @@ POST /test/doc/1/_create
 
 Include headers in the response
 
-#+BEGIN_SRC es :header yes
+#+BEGIN_SRC es
 GET /
 {}
 #+END_SRC


### PR DESCRIPTION
This patch removes the possibility to keep the header if the response is successful. However, it fixes the same problem we had in es-mode where utf-8 characters where not represented properly.

Someone should test this before we merge it. I might have forgotten some requires. If someone still needs the headers we should also reintroduce that.
