### PR TITLE
Enable company-es-backend in es-mode buffers only

### DIFF
--- a/es-mode.el
+++ b/es-mode.el
@@ -438,10 +438,12 @@ in which case it prompts the user."
  completion, if available."
   (interactive (list 'interactive))
   (cl-case command
-    (prefix (let ((sym (company-grab-symbol)))
-              (if (string-match "\"\\(.*\\)\"?" sym)
-                  (match-string 1 sym)
-                sym)))
+    (interactive (company-begin-backend 'es-company-backend))
+    (prefix (and (derived-mode-p 'es-mode)
+                 (let ((sym (company-grab-symbol)))
+                   (if (string-match "\"\\(.*\\)\"?" sym)
+                       (match-string 1 sym)
+                     sym))))
     (candidates
      (cl-remove-if-not
       (lambda (c) (string-prefix-p arg c))


### PR DESCRIPTION
Hi, thank you so much for this, it helped me a lot when working with Elasticsearch. This is just a simple pull request to restrict `company-es-back` in `es-mode` only. The issue I have is that when working in other mode buffers, sometimes the word match Elasticsearch keyword then I don't have the completions from other backends.