### PR TITLE
Modified jqheader quoting to be done with shell-quote-argument. 

### DIFF
--- a/ob-elasticsearch.el
+++ b/ob-elasticsearch.el
@@ -95,7 +95,7 @@ Does not move the point."
                     (shell-command-on-region
                      (point-min)
                      (point-max)
-                     (format "%s '%s'" es-jq-path jq-header)
+                     (format "%s %s" es-jq-path (shell-quote-argument jq-header))
                      (current-buffer)
                      t)))
                 (buffer-string))


### PR DESCRIPTION
Hi, es-mode is great.  I use it to give live ES query demos for presentations.  There's a small problem however with the shell handoff to jq in ob-elasticsearch.el.  Specifically, I'm using Windows which invokes jq through cmd.exe.  It does not understand explicit quoting with single quotes.

Bash handles this fine:

(format "%s '%s'" es-jq-path jq-header)

Cmd needs escaping that looks like this:

(format "%s \"%s\"" es-jq-path jq-header)

By appyling the shell-quote-argument to jqheader, it gets automatically adjusted to the operating system shell and works across OSes now. 