### PR TITLE
Delay evaluation of defaults for org-babel

### DIFF
--- a/ob-elasticsearch.el
+++ b/ob-elasticsearch.el
@@ -40,13 +40,6 @@
   :group 'es
   :type 'string)
 
-(defvar org-babel-default-header-args:es
-  `((:url    . ,es-default-url)
-    (:method . ,es-default-request-method)
-    (:jq     . nil))
-  "Default arguments for evaluating an elasticsearch query
-block.")
-
 (defvar org-babel-tangle-lang-exts)
 (add-to-list 'org-babel-tangle-lang-exts '("es" . "es"))
 
@@ -123,8 +116,8 @@ set to true, this function will also ask if the user really wants
 to do that."
   (with-temp-buffer
     (es-mode)
-    (setq es-request-method (upcase (cdr (assoc :method params))))
-    (setq es-endpoint-url (cdr (assoc :url params)))
+    (setq es-request-method (upcase (or (cdr (assoc :method params)) es-default-request-method)))
+    (setq es-endpoint-url (or (cdr (assoc :url params)) es-default-url))
     (insert (org-babel-expand-body:es body params))
     (beginning-of-buffer)
     (let ((output (es-org-execute-request


### PR DESCRIPTION
Hey @dakrone 

This package has been awesome for tinkering with Elasticsearch in emacs. Many thanks!

I ran into something that I think _might_ be a bug in the org-babel block handling. It looks like changing the values of the variables for default URL and default method does not take effect as one might expect.

Unlike (I assume) in proper es-mode buffers, org-babel blocks will continue to use the value of "es-default-url" and "...-method" **which were set at package load time**. This is because they are cached into the org-babel-default-header-args:es variable in defvar.

For example:

     #+NAME: a
     #+BEGIN_SRC es
     GET /_search?pretty
     { ... }
     #+END_SRC

     #+NAME: b
     #+BEGIN_SRC emacs-lisp
     (setq es-default-url "not-localhost:1234")
     #+BEGIN_SRC

     #+NAME: c
     #+BEGIN_SRC es
     GET /_search?pretty
     { ... }
     #+END_SRC

Assume these blocks are eval'd in order.

Without this change, blocks "a" and "c" will always request from "localhost:9000", or whatever was the custom value of "es-default-url" via customize-variable when the package was loaded.

With this change, block "c" will instead begin to use the new default url.

What do you think?