### PR TITLE
Use es-default-headers in es-org-execute-request.

### DIFF
--- a/ob-elasticsearch.el
+++ b/ob-elasticsearch.el
@@ -86,7 +86,7 @@ Does not move the point."
          (url (es--munge-url (cdr params)))
          (url-request-extra-headers
           (append
-           '(("Content-Type" . "application/json; charset=UTF-8"))
+           es-default-headers
            extra-headers))
          (url-request-data (encode-coding-string request-data 'utf-8)))
     (when (es--warn-on-delete-yes-or-no-p url-request-method)


### PR DESCRIPTION
Allow users to override the headers sent from ob-elasticsearch by customizing "es-default-headers" just as they can for es-mode.

Background: I am not able to connect directly to my work Elasticsearch instance but I can access it through Kibana. I have managed to advise various es-mode functions to proxy the Elasticsearch requests through Kibana, but Kibana gives me an error if the request doesn't include a `kbn-version` header. I've already set `es-default-headers` so that es-mode works, but ob-elasticsearch previously had its own hardcoded list of default headers. This fixes ob-elasticsearch to use `es-default-headers` instead.